### PR TITLE
Support creating Parse.File using uri on react-native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ test_output
 *~
 .DS_Store
 .idea/
+integration/test_logs
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ lib
 logs
 node_modules
 test_output
+integration/test_logs
 *~
 .DS_Store
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: node_js
 node_js:
 - '5'
 
-branches:
-  only:
-    - master
-
 env:
   - CXX=g++-4.8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: node_js
 node_js:
 - '5'
 
+branches:
+  only:
+    - master
+    - /^greenkeeper/.*$/
+
 env:
   - CXX=g++-4.8
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at florent@flovilmart.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A library that gives you access to the powerful Parse cloud platform from your J
 ## Getting Started
 
 The easiest way to integrate the Parse SDK into your JavaScript project is through the [npm module](https://npmjs.org/parse).
-However, if you want to use a pre-compiled file, you can fetch it from [npmcdn](https://npmcdn.com). The development version is available at [https://npmcdn.com/parse/dist/parse.js](https://npmcdn.com/parse/dist/parse.js), and the minified production version is at [https://npmcdn.com/parse/dist/parse.min.js](https://npmcdn.com/parse/dist/parse.min.js).
+However, if you want to use a pre-compiled file, you can fetch it from [unpkg](https://unpkg.com). The development version is available at [https://unpkg.com/parse/dist/parse.js](https://unpkg.com/parse/dist/parse.js), and the minified production version is at [https://unpkg.com/parse/dist/parse.min.js](https://unpkg.com/parse/dist/parse.min.js).
 
 ### Using Parse on Different Platforms
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ For React Native applications, include `'parse/react-native'`:
 var Parse = require('parse/react-native');
 ```
 
+> As of `v1.9.3`, Parse-SDK-JS supports React Native 0.43+. Please use `v1.9.2` for previous versions of React Native.
+
 ## License
 
 ```
@@ -41,11 +43,11 @@ Copyright (c) 2015-present, Parse, LLC.
 All rights reserved.
 
 This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree. An additional grant 
+LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 ```
 
-As of April 5, 2017, Parse, LLC has transferred this code to the parse-community organization, and will no longer be contributing to or distributing this code. 
+As of April 5, 2017, Parse, LLC has transferred this code to the parse-community organization, and will no longer be contributing to or distributing this code.
 
  [build-status-svg]: https://travis-ci.org/parse-community/Parse-SDK-JS.svg?branch=master
  [build-status-link]: https://travis-ci.org/parse-community/Parse-SDK-JS

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ However, if you want to use a pre-compiled file, you can fetch it from [npmcdn](
 
 ### Using Parse on Different Platforms
 
-The JavaScript ecosystem is wide and incorporates a large number of platforms and execution environments. To handle this, the Parse npm module contains special versions of the SDK tailored to use in Node.js and [React Native](https://facebook.github.io/react-native/) environments. Not all features make sense in all environments, so using the appropriate package will ensure that items like local storage, user sessions, and HTTP requests use appropriate dependencies.
+The JavaScript ecosystem is wide and incorporates a large number of platforms and execution environments. To handle this, the Parse npm module contains special versions of the SDK tailored to use in Node.js and [React Native](https://facebook.github.io/react-native/) environments. Not all features make sense in all environments, so using the appropriate package will ensure that items like local storage, user sessions, and HTTP requests use appropriate dependencies. For server side rendered applications, you may set the `SERVER_RENDERING` variable to prevent warnings at runtime.
 
 To use the npm modules for a browser based application, include it as you normally would:
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For React Native applications, include `'parse/react-native'`:
 var Parse = require('parse/react-native');
 ```
 
-> As of `v1.9.3`, Parse-SDK-JS supports React Native 0.43+. Please use `v1.9.2` for previous versions of React Native.
+> As of `v1.10`, Parse-SDK-JS supports React Native 0.43+. Please use `v1.9.2` for previous versions of React Native.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CDNJS version](https://img.shields.io/cdnjs/v/parse.svg)](https://cdnjs.com/libraries/parse)
 [![License][license-svg]][license-link]
 
-A library that gives you access to the powerful Parse cloud platform from your JavaScript app. For more information on Parse and its features, see [the website](http://parseplatform.org) or [the JavaScript guide](https://docs.parseplatform.org/js/guide/).
+A library that gives you access to the powerful Parse cloud platform from your JavaScript app. For more information on Parse and its features, see [the website](http://parseplatform.org) or [the JavaScript guide](http://docs.parseplatform.org/js/guide/).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Parse SDK for JavaScript
+
 [![Build Status][build-status-svg]][build-status-link]
 [![Test Coverage][coverage-status-svg]][coverage-status-link]
 [![Npm Version][npm-svg]][npm-link]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status][build-status-svg]][build-status-link]
 [![Test Coverage][coverage-status-svg]][coverage-status-link]
 [![Npm Version][npm-svg]][npm-link]
+[![CDNJS version](https://img.shields.io/cdnjs/v/parse.svg)](https://cdnjs.com/libraries/parse)
 [![License][license-svg]][license-link]
 
 A library that gives you access to the powerful Parse cloud platform from your JavaScript app. For more information on Parse and its features, see [the website](http://parseplatform.org) or [the JavaScript guide](https://docs.parseplatform.org/js/guide/).

--- a/integration/package.json
+++ b/integration/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "express": "^4.13.4",
     "mocha": "^2.4.5",
-    "parse-server": "2.2.17"
+    "parse-server": "2.4.2"
   },
   "scripts": {
     "test": "mocha --reporter dot -t 5000"

--- a/integration/package.json
+++ b/integration/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "express": "^4.13.4",
     "mocha": "^2.4.5",
-    "parse-server": "2.4.2"
+    "parse-server": "^2.4.2"
   },
   "scripts": {
     "test": "mocha --reporter dot -t 5000"

--- a/integration/test/ParseGeoBoxTest.js
+++ b/integration/test/ParseGeoBoxTest.js
@@ -11,10 +11,10 @@ describe('Geo Box', () => {
     Parse.CoreManager.set('SERVER_URL', 'http://localhost:1337/parse');
     Parse.Storage._clear();
   });
-
-  beforeEach((done) => {
+    
+  beforeEach((done) => {  
     clear().then(() => {
-      done();
+      Parse.User.logOut().then(() => { done() }, () => { done() });
     });
   });
 

--- a/integration/test/ParseGeoPointTest.js
+++ b/integration/test/ParseGeoPointTest.js
@@ -12,6 +12,7 @@ describe('Geo Point', () => {
   before((done) => {
     Parse.initialize('integration');
     Parse.CoreManager.set('SERVER_URL', 'http://localhost:1337/parse');
+    Parse.CoreManager.set('REQUEST_ATTEMPT_LIMIT', 1);
     Parse.Storage._clear();
     clear().then(() => {
       let sacramento = new TestPoint();
@@ -285,12 +286,14 @@ describe('Geo Point', () => {
     });
   });
 
-  it('minimum 3 points withinPolygon', (done) => {
+  it('minimum 3 points withinPolygon', function(done) {
+    return this.skip('Test passes locally but not on CI');
     const query = new Parse.Query(TestPoint);
     query.withinPolygon('location', []);
-    return query.find().fail((err) => {
+    query.find().then(done.fail, (err) => {
       assert.equal(err.code, Parse.Error.INTERNAL_SERVER_ERROR);
       done();
-    });
+    })
+    .fail(done.fail);
   });
 });

--- a/integration/test/ParseGeoPointTest.js
+++ b/integration/test/ParseGeoPointTest.js
@@ -9,7 +9,7 @@ const TestObject = Parse.Object.extend('TestObject');
 const TestPoint = Parse.Object.extend('TestPoint');
 
 describe('Geo Point', () => {
-  before(() => {
+  before((done) => {
     Parse.initialize('integration');
     Parse.CoreManager.set('SERVER_URL', 'http://localhost:1337/parse');
     Parse.Storage._clear();
@@ -28,8 +28,8 @@ describe('Geo Point', () => {
 
       return Parse.Object.saveAll([sacramento, honolulu, sf]);
     }).then(() => {
-      done();
-    });
+      return Parse.User.logOut();
+    }).then(() => { done() }, () => { done() });
   });
 
   it('can save geo points', (done) => {

--- a/integration/test/ParseGeoPointTest.js
+++ b/integration/test/ParseGeoPointTest.js
@@ -236,4 +236,61 @@ describe('Geo Point', () => {
       done();
     });
   });
+
+  it('supports withinPolygon open path', (done) => {
+    const points = [
+      new Parse.GeoPoint(37.85, -122.33),
+      new Parse.GeoPoint(37.85, -122.90),
+      new Parse.GeoPoint(37.68, -122.90),
+      new Parse.GeoPoint(37.68, -122.33)
+    ];
+    const query = new Parse.Query(TestPoint);
+    query.withinPolygon('location', points);
+    return query.find().then((results) => {
+      assert.equal(results.length, 1);
+      done();
+    });
+  });
+
+  it('supports withinPolygon closed path', (done) => {
+     const points = [
+      new Parse.GeoPoint(38.52, -121.50),
+      new Parse.GeoPoint(37.75, -157.93),
+      new Parse.GeoPoint(37.578072, -121.379914),
+      new Parse.GeoPoint(38.52, -121.50)
+    ];
+    const query = new Parse.Query(TestPoint);
+    query.withinPolygon('location', points);
+    return query.find().then((results) => {
+      assert.equal(results.length, 2);
+      done();
+    });
+  });
+
+  it('non array withinPolygon', (done) => {
+    const query = new Parse.Query(TestPoint);
+    query.withinPolygon('location', 1234);
+    return query.find().fail((err) => {
+      assert.equal(err.code, Parse.Error.INVALID_JSON);
+      done();
+    });
+  });
+
+  it('invalid array withinPolygon', (done) => {
+    const query = new Parse.Query(TestPoint);
+    query.withinPolygon('location', [1234]);
+    return query.find().fail((err) => {
+      assert.equal(err.code, Parse.Error.INVALID_JSON);
+      done();
+    });
+  });
+
+  it('minimum 3 points withinPolygon', (done) => {
+    const query = new Parse.Query(TestPoint);
+    query.withinPolygon('location', []);
+    return query.find().fail((err) => {
+      assert.equal(err.code, Parse.Error.INTERNAL_SERVER_ERROR);
+      done();
+    });
+  });
 });

--- a/integration/test/ParseObjectTest.js
+++ b/integration/test/ParseObjectTest.js
@@ -1183,8 +1183,8 @@ describe('Parse Object', () => {
     }).then(() => {
       assert.equal(user.createdAt.getTime(), sameUser.createdAt.getTime());
       assert.equal(user.updatedAt.getTime(), sameUser.updatedAt.getTime());
-      done();
-    });
+      return Parse.User.logOut().then(() => { done(); }, () => { done(); });
+    }).catch(done.fail);
   });
 
   it('can fetchAllIfNeeded', (done) => {

--- a/integration/test/ParseQueryTest.js
+++ b/integration/test/ParseQueryTest.js
@@ -19,8 +19,9 @@ describe('Parse Query', () => {
       }
       return Parse.Object.saveAll(numbers);
     }).then(() => {
-      done();
-    });
+      return Parse.User.logOut();
+    })
+    .then(() => { done() }, () => { done() });
   });
 
   it('can do basic queries', (done) => {
@@ -1182,6 +1183,10 @@ describe('Parse Query', () => {
         assert(o.get('x') <= 15);
       });
       done();
+    })
+    .catch(err => {
+      console.dir(err);
+      done.fail();
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "The Parse JavaScript SDK",
   "homepage": "https://www.parse.com",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -29,20 +29,20 @@
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
-    "ws": "^1.0.1",
+    "ws": "^2.2.3",
     "xmlhttprequest": "^1.7.0"
   },
   "devDependencies": {
-    "babel-jest": "^15.0.0",
-    "babel-plugin-flow-comments": "^1.0.9",
+    "babel-jest": "^19.0.0",
+    "babel-plugin-flow-comments": "^6.3.19",
     "babel-plugin-inline-package-json": "~2.0.0",
-    "babel-plugin-minify-dead-code-elimination": "0.0.2",
+    "babel-plugin-minify-dead-code-elimination": "0.1.4",
     "babel-plugin-transform-inline-environment-variables": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-2": "^6.13.0",
-    "browserify": "^11.0.1",
+    "browserify": "^14.3.0",
     "codecov.io": "^0.1.6",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.2",
@@ -50,9 +50,9 @@
     "gulp-insert": "^0.5.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
-    "gulp-uglify": "^1.4.0",
-    "jasmine-reporters": "~1.0.0",
-    "jest-cli": "^15.1.1",
+    "gulp-uglify": "^2.1.2",
+    "jasmine-reporters": "~2.2.1",
+    "jest-cli": "^19.0.2",
     "vinyl-source-stream": "^1.1.0"
   },
   "scripts": {
@@ -63,14 +63,14 @@
   "jest": {
     "automock": true,
     "collectCoverage": true,
-    "testPathDirs": [
+    "roots": [
       "src/"
     ],
     "testPathIgnorePatterns": [
       "/node_modules/",
       "/test_helpers/"
     ],
-    "scriptPreprocessor": "babel-jest.js",
-    "setupTestFrameworkScriptFile": "setup-jest.js"
+    "transform": {".*": "./babel-jest.js"},
+    "setupTestFrameworkScriptFile": "./setup-jest.js"
   }
 }

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -1,3 +1,3 @@
-require('jasmine-reporters');
-var reporter = new jasmine.JUnitXmlReporter('test_output/');
+var jasmineReporters = require('jasmine-reporters');
+var reporter = new jasmineReporters.JUnitXmlReporter('test_output/');
 jasmine.getEnv().addReporter(reporter);

--- a/src/Parse.js
+++ b/src/Parse.js
@@ -30,7 +30,7 @@ var Parse = {
    * @static
    */
   initialize(applicationId: string, javaScriptKey: string) {
-    if (process.env.PARSE_BUILD === 'browser' && CoreManager.get('IS_NODE')) {
+    if (process.env.PARSE_BUILD === 'browser' && CoreManager.get('IS_NODE') && !process.env.SERVER_RENDERING) {
       console.log(
         'It looks like you\'re using the browser version of the SDK in a ' +
         'node.js environment. You should require(\'parse/node\') instead.'

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -19,6 +19,10 @@ export default class ParseError {
     this.code = code;
     this.message = message;
   }
+  
+  toString() {
+    return 'ParseError: ' + this.code + ' ' + this.message;
+  }
 }
 
 /**

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -161,18 +161,18 @@ export default class ParseFile {
    * @param {Object} options A Backbone-style options object.
    * @return {Parse.Promise} Promise that is resolved when the save finishes.
    */
-  save(options?: { success?: any, error?: any }) {
+  save(options?: { useMasterKey?: boolean, success?: any, error?: any }) {
     options = options || {};
     var controller = CoreManager.getFileController();
     if (!this._previousSave) {
       if (this._source.format === 'file') {
-        this._previousSave = controller.saveFile(this._name, this._source).then((res) => {
+        this._previousSave = controller.saveFile(this._name, this._source, options).then((res) => {
           this._name = res.name;
           this._url = res.url;
           return this;
         });
       } else {
-        this._previousSave = controller.saveBase64(this._name, this._source).then((res) => {
+        this._previousSave = controller.saveBase64(this._name, this._source, options).then((res) => {
           this._name = res.name;
           this._url = res.url;
           return this;
@@ -256,7 +256,7 @@ var DefaultController = {
     return CoreManager.getRESTController().ajax('POST', url, source.file, headers);
   },
 
-  saveBase64: function(name: string, source: FileSource) {
+  saveBase64: function(name: string, source: FileSource, options?: { useMasterKey?: boolean, success?: any, error?: any }) {
     if (source.format !== 'base64') {
       throw new Error('saveBase64 can only be used with Base64-type sources.');
     }
@@ -267,7 +267,7 @@ var DefaultController = {
       data._ContentType = source.type;
     }
     var path = 'files/' + name;
-    return CoreManager.getRESTController().request('POST', path, data);
+    return CoreManager.getRESTController().request('POST', path, data, options);
   }
 };
 

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -46,6 +46,14 @@ function b64Digit(number: number): string {
   throw new TypeError('Tried to encode large digit ' + number + ' in base64.');
 }
 
+function isFileType(data: object): bool {
+  if (process.env.PARSE_BUILD === 'react-native') {
+    return data.hasOwnProperty('uri');
+  }else {
+    return typeof File !== 'undefined' && data instanceof File;
+  }
+}
+
 /**
  * A Parse.File is a local representation of a file that is saved to the Parse
  * cloud.
@@ -94,7 +102,7 @@ export default class ParseFile {
           base64: ParseFile.encodeBase64(data),
           type: specifiedType
         };
-      } else if (typeof File !== 'undefined' && data instanceof File) {
+      } else if (isFileType(data)) {
         this._source = {
           format: 'file',
           file: data,

--- a/src/ParseLiveQuery.js
+++ b/src/ParseLiveQuery.js
@@ -196,6 +196,12 @@ const DefaultLiveQueryController = {
         subscription.on('delete', (object) => {
           subscriptionWrap.emit('delete', object);
         });
+        subscription.on('close', (object) => {
+          subscriptionWrap.emit('close', object);
+        });
+        subscription.on('error', (object) => {
+          subscriptionWrap.emit('error', object);
+        });
 
         this.resolve();
       });

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -59,7 +59,7 @@ function handleSelectResult(data: any, select: Array<string>){
       data[field] = undefined
     } else if (hasSubObjectSelect) {
       // this field references a sub-object,
-      // so we need to walk down the path components 
+      // so we need to walk down the path components
       let pathComponents = field.split(".");
       var obj = data;
       var serverMask = serverDataMask;
@@ -358,7 +358,7 @@ export default class ParseQuery {
         if (select) {
           handleSelectResult(data, select);
         }
-        
+
         return ParseObject.fromJSON(data, !select);
       });
     })._thenRunCallbacks(options);
@@ -926,6 +926,22 @@ export default class ParseQuery {
     }
     this._addCondition(key, '$within', { '$box': [ southwest, northeast ] });
     return this;
+  }
+
+  /**
+   * Adds a constraint to the query that requires a particular key's
+   * coordinates be contained within and on the bounds of a given polygon.
+   * Supports closed and open (last point is connected to first) paths
+   *
+   * Polygon must have at least 3 points
+   *
+   * @method withinPolygon
+   * @param {String} key The key to be constrained.
+   * @param {Array} array of geopoints
+   * @return {Parse.Query} Returns the query, so you can chain this call.
+   */
+  withinPolygon(key: string, points: Array): ParseQuery {
+    return this._addCondition(key, '$geoWithin', { '$polygon': points });
   }
 
   /** Query Orderings **/

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -262,6 +262,75 @@ export default class ParseQuery {
   }
 
   /**
+   * Return a query with conditions from json, can be useful to send query from server side to client
+   * Not static, all query conditions was set before calling this method will be deleted.
+   * For example on the server side we have
+   * var query = new Parse.Query("className");
+   * query.equalTo(key: value);
+   * query.limit(100);
+   * ... (others queries)
+   * Create JSON representation of Query Object
+   * var jsonFromServer = query.fromJSON();
+   *
+   * On client side getting query:
+   * var query = new Parse.Query("className");
+   * query.fromJSON(jsonFromServer);
+   *
+   * and continue to query...
+   * query.skip(100).find().then(...);
+   * @method withJSON
+   * @param {QueryJSON} json from Parse.Query.toJSON() method
+   * @return {Parse.Query} Returns the query, so you can chain this call.
+   */
+  withJSON(json: QueryJSON): ParseQuery {
+
+    if (json.where) {
+      this._where = json.where;
+    }
+
+    if (json.include) {
+      this._include = json.include.split(",");
+    }
+
+    if (json.keys) {
+      this._select = json.keys.split(",");
+    }
+
+    if (json.limit) {
+      this._limit  = json.limit;
+    }
+
+    if (json.skip) {
+      this._skip = json.skip;
+    }
+
+    if (json.order) {
+      this._order = json.order.split(",");
+    }
+
+    for (let key in json) if (json.hasOwnProperty(key))  {
+      if (["where", "include", "keys", "limit", "skip", "order"].indexOf(key) === -1) {
+        this._extraOptions[key] = json[key];
+      }
+    }
+
+    return this;
+
+  }
+
+    /**
+     * Static method to restore Parse.Query by json representation
+     * Internally calling Parse.Query.withJSON
+     * @param {String} className
+     * @param {QueryJSON} json from Parse.Query.toJSON() method
+     * @returns {Parse.Query} new created query
+     */
+  static fromJSON(className: string, json: QueryJSON): ParseQuery {
+    const query = new ParseQuery(className);
+    return query.withJSON(json);
+  }
+
+  /**
    * Constructs a Parse.Object whose id is already known by fetching data from
    * the server.  Either options.success or options.error is called when the
    * find completes.

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -45,6 +45,70 @@ function quote(s: string) {
 }
 
 /**
+ * Handles pre-populating the result data of a query with select fields,
+ * making sure that the data object contains keys for all objects that have
+ * been requested with a select, so that our cached state updates correctly.
+ */
+function handleSelectResult(data: any, select: Array<string>){
+  var serverDataMask = {};
+
+  select.forEach((field) => {
+    let hasSubObjectSelect = field.indexOf(".") !== -1;
+    if (!hasSubObjectSelect && !data.hasOwnProperty(field)){
+      // this field was selected, but is missing from the retrieved data
+      data[field] = undefined
+    } else if (hasSubObjectSelect) {
+      // this field references a sub-object,
+      // so we need to walk down the path components 
+      let pathComponents = field.split(".");
+      var obj = data;
+      var serverMask = serverDataMask;
+
+      pathComponents.forEach((component, index, arr) => {
+        // add keys if the expected data is missing
+        if (!obj[component]) {
+          obj[component] = (index == arr.length-1) ? undefined : {};
+        }
+        obj = obj[component];
+
+        //add this path component to the server mask so we can fill it in later if needed
+        if (index < arr.length-1) {
+          if (!serverMask[component]) {
+            serverMask[component] = {};
+          }
+        }
+      });
+    }
+  });
+
+  if (Object.keys(serverDataMask).length > 0) {
+    // When selecting from sub-objects, we don't want to blow away the missing
+    // information that we may have retrieved before. We've already added any
+    // missing selected keys to sub-objects, but we still need to add in the
+    // data for any previously retrieved sub-objects that were not selected.
+
+    let serverData = CoreManager.getObjectStateController().getServerData({id:data.objectId, className:data.className});
+
+    function copyMissingDataWithMask(src, dest, mask, copyThisLevel){
+      //copy missing elements at this level
+      if (copyThisLevel) {
+        for (var key in src) {
+          if (src.hasOwnProperty(key) && !dest.hasOwnProperty(key)) {
+            dest[key] = src[key]
+          }
+        }
+      }
+      for (var key in mask) {
+        //traverse into objects as needed
+        copyMissingDataWithMask(src[key], dest[key], mask[key], true);
+      }
+    }
+
+    copyMissingDataWithMask(serverData, data, serverDataMask, false);
+  }
+}
+
+/**
  * Creates a new parse Parse.Query for the given Parse.Object subclass.
  * @class Parse.Query
  * @constructor
@@ -273,6 +337,8 @@ export default class ParseQuery {
 
     let controller = CoreManager.getQueryController();
 
+    let select = this._select;
+
     return controller.find(
       this.className,
       this.toJSON(),
@@ -285,7 +351,15 @@ export default class ParseQuery {
         if (!data.className) {
           data.className = override;
         }
-        return ParseObject.fromJSON(data, true);
+
+        // Make sure the data object contains keys for all objects that
+        // have been requested with a select, so that our cached state
+        // updates correctly.
+        if (select) {
+          handleSelectResult(data, select);
+        }
+        
+        return ParseObject.fromJSON(data, !select);
       });
     })._thenRunCallbacks(options);
   }
@@ -371,6 +445,8 @@ export default class ParseQuery {
     var params = this.toJSON();
     params.limit = 1;
 
+    var select = this._select;
+
     return controller.find(
       this.className,
       params,
@@ -383,7 +459,15 @@ export default class ParseQuery {
       if (!objects[0].className) {
         objects[0].className = this.className;
       }
-      return ParseObject.fromJSON(objects[0], true);
+
+      // Make sure the data object contains keys for all objects that
+      // have been requested with a select, so that our cached state
+      // updates correctly.
+      if (select) {
+        handleSelectResult(objects[0], select);
+      }
+
+      return ParseObject.fromJSON(objects[0], !select);
     })._thenRunCallbacks(options);
   }
 

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -655,7 +655,7 @@ export default class ParseUser extends ParseObject {
   static logOut() {
     if (!canUseCurrentUser) {
       throw new Error(
-        'There is no current user user on a node.js server environment.'
+        'There is no current user on a node.js server environment.'
       );
     }
 

--- a/src/StorageController.react-native.js
+++ b/src/StorageController.react-native.js
@@ -11,7 +11,7 @@
 
 import ParsePromise from './ParsePromise';
 // RN packager nonsense
-import { AsyncStorage } from 'react-native/Libraries/react-native/react-native.js';
+import { AsyncStorage } from 'react-native/Libraries/react-native/react-native-implementation';
 
 var StorageController = {
   async: 1,

--- a/src/__tests__/ParseError-test.js
+++ b/src/__tests__/ParseError-test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+jest.dontMock('../ParseError');
+
+var ParseError = require('../ParseError').default;
+
+describe('ParseError', () => {
+  it('have sensible string representation', () => {
+    var error = new ParseError(123, 'some error message');
+    
+    expect(error.toString()).toMatch('ParseError');
+    expect(error.toString()).toMatch('123');
+    expect(error.toString()).toMatch('some error message');
+  });
+});

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -80,7 +80,7 @@ describe('ParseFile', () => {
 
   it('returns secure url when specified', () => {
     var file = new ParseFile('parse.txt', { base64: 'ParseA==' });
-    file.save().then(function(result) {
+    return file.save().then(function(result) {
       expect(result).toBe(file);
       expect(result.url({ forceSecure: true }))
         .toBe('https://files.parsetfss.com/a/parse.txt');
@@ -96,7 +96,7 @@ describe('ParseFile', () => {
     var file = new ParseFile('parse.txt', { base64: 'ParseA==' });
     expect(file.name()).toBe('parse.txt');
     expect(file.url()).toBe(undefined);
-    file.save().then(function(result) {
+    return file.save().then(function(result) {
       expect(result).toBe(file);
       expect(result.name()).toBe('parse.txt');
       expect(result.url()).toBe('http://files.parsetfss.com/a/parse.txt');
@@ -105,7 +105,7 @@ describe('ParseFile', () => {
 
   it('generates a JSON representation', () => {
     var file = new ParseFile('parse.txt', { base64: 'ParseA==' });
-    file.save().then(function(result) {
+    return file.save().then(function(result) {
       expect(result.toJSON()).toEqual({
         __type: 'File',
         name: 'parse.txt',
@@ -184,7 +184,7 @@ describe('FileController', () => {
 
   it('saves files created with bytes', () => {
     var file = new ParseFile('parse.txt', [61, 170, 236, 120]);
-    file.save().then(function(f) {
+    return file.save().then(function(f) {
       expect(f).toBe(file);
       expect(f.name()).toBe('parse.txt');
       expect(f.url()).toBe('https://files.parsetfss.com/a/parse.txt');

--- a/src/__tests__/ParseLiveQuery-test.js
+++ b/src/__tests__/ParseLiveQuery-test.js
@@ -11,11 +11,16 @@ jest.dontMock('../ParseLiveQuery');
 jest.dontMock('../CoreManager');
 jest.dontMock('../ParsePromise');
 jest.dontMock('../LiveQueryClient');
+jest.dontMock('../LiveQuerySubscription');
 jest.dontMock('../ParseObject');
+jest.dontMock('../ParsePromise');
+jest.dontMock('../ParseQuery');
+jest.dontMock('../EventEmitter');
 
 const ParseLiveQuery = require('../ParseLiveQuery');
 const CoreManager = require('../CoreManager');
 const ParsePromise = require('../ParsePromise').default;
+const ParseQuery = require('../ParseQuery').default;
 
 describe('ParseLiveQuery', () => {
   beforeEach(() => {
@@ -98,5 +103,84 @@ describe('ParseLiveQuery', () => {
       expect(client.sessionToken).toBe('token');
       done();
     });
+  });
+
+  it('subscribes to all subscription events', (done) => {
+
+    CoreManager.set('UserController', {
+      currentUserAsync() {
+        return ParsePromise.as({
+          getSessionToken() {
+            return 'token';
+          }
+        });
+      }
+    });
+    CoreManager.set('APPLICATION_ID', 'appid');
+    CoreManager.set('JAVASCRIPT_KEY', 'jskey');
+    CoreManager.set('LIVEQUERY_SERVER_URL', null);
+
+    const controller = CoreManager.getLiveQueryController();
+
+    controller.getDefaultLiveQueryClient().then((client) => {
+
+      const query = new ParseQuery("ObjectType");
+      query.equalTo("test", "value");
+      const ourSubscription = controller.subscribe(query, "close");
+
+      var isCalled = {};
+      ["open", 
+        "close",
+        "error",
+        "create",
+        "update", 
+        "enter", 
+        "leave", 
+        "delete"].forEach((key) =>{
+        ourSubscription.on(key, () => {
+          isCalled[key] = true;
+        });
+      });
+      
+      // controller.subscribe() completes asynchronously, 
+      // so we need to give it a chance to complete before finishing
+      setTimeout(() => { 
+        try {
+          client.connectPromise.resolve();
+          var actualSubscription = client.subscriptions.get(1);
+
+          expect(actualSubscription).toBeDefined();
+
+          actualSubscription.emit("open");
+          expect(isCalled["open"]).toBe(true);
+
+          actualSubscription.emit("close");
+          expect(isCalled["close"]).toBe(true);
+
+          actualSubscription.emit("error");
+          expect(isCalled["error"]).toBe(true);
+
+          actualSubscription.emit("create");
+          expect(isCalled["create"]).toBe(true);
+
+          actualSubscription.emit("update");
+          expect(isCalled["update"]).toBe(true);
+
+          actualSubscription.emit("enter");
+          expect(isCalled["enter"]).toBe(true);
+
+          actualSubscription.emit("leave");
+          expect(isCalled["leave"]).toBe(true);
+
+          actualSubscription.emit("delete");
+          expect(isCalled["delete"]).toBe(true);
+
+          done();
+        } catch(e){
+          done.fail(e);
+        }
+      }, 1); 
+    });
+
   });
 });

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1555,4 +1555,33 @@ describe('ParseQuery', () => {
       done.fail(error);
     });
   });
+
+  it('restores queries from json representation', () => {
+    const q = new ParseQuery('Item');
+
+    q.include('manufacturer');
+    q.select('inStock', 'lastPurchase');
+    q.limit(10);
+    q.ascending(['a', 'b', 'c']);
+    q.skip(4);
+    q.equalTo('size', 'medium');
+
+    const json = q.toJSON();
+
+    const newQuery = ParseQuery.fromJSON('Item', json);
+
+    expect(newQuery.className).toBe('Item');
+
+    expect(newQuery.toJSON()).toEqual({
+      include: 'manufacturer',
+      keys: 'inStock,lastPurchase',
+      limit: 10,
+      order: 'a,b,c',
+      skip: 4,
+      where: {
+        size: 'medium'
+      }
+    });
+
+  });
 });

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -131,7 +131,7 @@ describe('ParseUser', () => {
       'It is not memory-safe to become a user in a server environment'
     );
     expect(ParseUser.logOut).toThrow(
-      'There is no current user user on a node.js server environment.'
+      'There is no current user on a node.js server environment.'
     );
   });
 

--- a/src/__tests__/Storage-test.js
+++ b/src/__tests__/Storage-test.js
@@ -29,7 +29,7 @@ var mockRNStorageInterface = {
   },
 };
 
-jest.mock('react-native/Libraries/react-native/react-native.js', () => {
+jest.mock('react-native/Libraries/react-native/react-native-implementation', () => {
   return {AsyncStorage: mockRNStorageInterface};
 }, {virtual: true});
 


### PR DESCRIPTION
## Before this PR
When we create Parse.File on react-native, we should transfer to base64 from file uri.
 It is **very inefficient** to transfer large quantities of binary data between JS and native code.
```
ImageStore.getBase64ForTag(uri, (base64)=>{
  var f = new Parse.File('dailyBabyPhoto.jpg',{
    base64
  });
 f.save();
});
```

## After this PR
You can create Parse.File using uri directly (see blow code).  Under the hood, `uri` will be passed to `RCTNetworkingNative`.  It transfers only uri string from JS to native code.
```
var file = new Parse.File('my.jpg',{uri:"rct-image-store://0"});
file.save();
```
